### PR TITLE
Add support for Laravel 6+

### DIFF
--- a/src/Routes/Collection.php
+++ b/src/Routes/Collection.php
@@ -3,6 +3,7 @@
 namespace SamTurrell\Laroute\Routes;
 
 use Illuminate\Routing\Route;
+use Illuminate\Support\Arr;
 use Lord\Laroute\Routes\Collection as BaseCollection;
 
 class Collection extends BaseCollection
@@ -36,6 +37,6 @@ class Collection extends BaseCollection
             return null;
         }
 
-        return array_only($data, ['uri', 'name']);
+        return Arr::only($data, ['uri', 'name']);
     }
 }


### PR DESCRIPTION
The package currently uses `array_only` which has been removed in favour of `Arr::only()`. This PR makes this switch to allow the package to work with Laravel 6+ whilst maintaining backwards compatibility.