### PR TITLE
fix-to-array Replaces 'toArray()' with 'jsonSerialize()'

### DIFF
--- a/src/Routes/Collection.php
+++ b/src/Routes/Collection.php
@@ -17,7 +17,7 @@ class Collection extends BaseCollection
     {
         $options = JSON_PRETTY_PRINT | $options;
 
-        return json_encode($this->toArray(), $options);
+        return json_encode($this->jsonSerialize(), $options);
     }
 
     /**


### PR DESCRIPTION
Regenerating laroute.js breaks. Using jsonSerialize() fixes the issue.